### PR TITLE
Fix: Single warning is processed differently

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -291,9 +291,14 @@ class Dispatcher {
      */
     private function processWarnings($warnings) {
         $result = array();
-        foreach ($warnings as $warning) {
-            $result[\intval($warning->kod_varov)] 
-              = $this->getWarnigMsg($warning->kod_varov);
+        if(\count($warnings) === 1) {
+            $result[\intval($warnings->kod_varov)]
+                    = $this->getWarnigMsg($warnings->kod_varov);
+        } else {
+            foreach ($warnings as $warning) {
+                $result[\intval($warning->kod_varov)]
+                  = $this->getWarnigMsg($warning->kod_varov);
+            }
         }
         return $result;
     }


### PR DESCRIPTION
Default PHP SOAP conversion to stdClass is little bit tricky...