### PR TITLE
update - exclude non updated values

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -241,14 +241,14 @@ class Dispatcher {
     }
 
     public function prepareData($receipt, $check = FALSE) {
-        $head = Format::unsetInvalidKeys([
+        $head = [
             'uuid_zpravy' => $receipt->uuid_zpravy,
             'dat_odesl' => time(),
             'prvni_zaslani' => $receipt->prvni_zaslani,
             'overeni' => $check
-        ]);
+        ];
 
-        $body = Format::unsetInvalidKeys([
+        $body = [
             'dic_popl' => $receipt->dic_popl,
             'dic_poverujiciho' => $receipt->dic_poverujiciho,
             'id_provoz' => $receipt->id_provoz,
@@ -270,7 +270,7 @@ class Dispatcher {
             'urceno_cerp_zuct' => Format::price($receipt->urceno_cerp_zuct),
             'cerp_zuct' => Format::price($receipt->cerp_zuct),
             'rezim' => $receipt->rezim
-        ]);
+        ];
 		
         return [
             'Hlavicka' => $head,

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -13,7 +13,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
  * Receipt for Ministry of Finance
  */
 class Dispatcher {
-
+	
     /**
      * Certificate key
      * @var string
@@ -241,14 +241,14 @@ class Dispatcher {
     }
 
     public function prepareData($receipt, $check = FALSE) {
-        $head = [
+        $head = Format::unsetInvalidKeys([
             'uuid_zpravy' => $receipt->uuid_zpravy,
             'dat_odesl' => time(),
             'prvni_zaslani' => $receipt->prvni_zaslani,
             'overeni' => $check
-        ];
+        ]);
 
-        $body = [
+        $body = Format::unsetInvalidKeys([
             'dic_popl' => $receipt->dic_popl,
             'dic_poverujiciho' => $receipt->dic_poverujiciho,
             'id_provoz' => $receipt->id_provoz,
@@ -270,8 +270,8 @@ class Dispatcher {
             'urceno_cerp_zuct' => Format::price($receipt->urceno_cerp_zuct),
             'cerp_zuct' => Format::price($receipt->cerp_zuct),
             'rezim' => $receipt->rezim
-        ];
-
+        ]);
+		
         return [
             'Hlavicka' => $head,
             'Data' => $body,
@@ -371,7 +371,5 @@ class Dispatcher {
     public function getBkpCode() {
         return $this->bkpCode;
     }
-    
-    
 
 }

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -14,7 +14,7 @@ class Receipt {
     /**
      * Head part: message identifier
      * @var string */
-    public $uuid_zpravy;
+    public $uuid_zpravy = FALSE;
 
     /**
      * Head part: first sending
@@ -22,66 +22,66 @@ class Receipt {
     public $prvni_zaslani = TRUE;
 
     /** @var string */
-    public $dic_popl;
+    public $dic_popl = FALSE;
 
     /** @var string */
-    public $dic_poverujiciho;
+    public $dic_poverujiciho = FALSE;
 
     /** @var string */
-    public $id_provoz;
+    public $id_provoz = FALSE;
 
     /** @var string */
-    public $id_pokl;
+    public $id_pokl = FALSE;
 
     /** @var string */
-    public $porad_cis;
+    public $porad_cis = FALSE;
 
     /** @var \DateTime */
-    public $dat_trzby;
+    public $dat_trzby = FALSE;
 
     /** @var float */
-    public $celk_trzba = 0;
+    public $celk_trzba = FALSE;
 
     /** @var float */
-    public $zakl_nepodl_dph = 0;
+    public $zakl_nepodl_dph = FALSE;
 
     /** @var float */
-    public $zakl_dan1 = 0;
+    public $zakl_dan1 = FALSE;
 
     /** @var float */
-    public $dan1 = 0;
+    public $dan1 = FALSE;
 
     /** @var float */
-    public $zakl_dan2 = 0;
+    public $zakl_dan2 = FALSE;
 
     /** @var float */
-    public $dan2 = 0;
+    public $dan2 = FALSE;
 
     /** @var float */
-    public $zakl_dan3 = 0;
+    public $zakl_dan3 = FALSE;
 
     /** @var float */
-    public $dan3 = 0;
+    public $dan3 = FALSE;
 
     /** @var float */
-    public $cest_sluz = 0;
+    public $cest_sluz = FALSE;
 
     /** @var float */
-    public $pouzit_zboz1 = 0;
+    public $pouzit_zboz1 = FALSE;
 
     /** @var float */
-    public $pouzit_zboz2 = 0;
+    public $pouzit_zboz2 = FALSE;
 
     /** @var float */
-    public $pouzit_zboz3 = 0;
+    public $pouzit_zboz3 = FALSE;
 
     /** @var float */
-    public $urceno_cerp_zuct = 0;
+    public $urceno_cerp_zuct = FALSE;
 
     /** @var float */
-    public $cerp_zuct = 0;
+    public $cerp_zuct = FALSE;
 
     /** @var int */
-    public $rezim = 0;
+    public $rezim = FALSE;
 
 }

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -43,43 +43,43 @@ class Receipt {
     public $celk_trzba;
 
     /** @var float */
-    public $zakl_nepodl_dph = null;
+    public $zakl_nepodl_dph;
 
     /** @var float */
-    public $zakl_dan1 = null;
+    public $zakl_dan1;
 
     /** @var float */
-    public $dan1 = null;
+    public $dan1;
 
     /** @var float */
-    public $zakl_dan2 = null;
+    public $zakl_dan2;
 
     /** @var float */
-    public $dan2 = null;
+    public $dan2;
 
     /** @var float */
-    public $zakl_dan3 = null;
+    public $zakl_dan3;
 
     /** @var float */
-    public $dan3 = null;
+    public $dan3;
 
     /** @var float */
-    public $cest_sluz = null;
+    public $cest_sluz;
 
     /** @var float */
-    public $pouzit_zboz1 = null;
+    public $pouzit_zboz1;
 
     /** @var float */
-    public $pouzit_zboz2 = null;
+    public $pouzit_zboz2;
 
     /** @var float */
-    public $pouzit_zboz3 = null;
+    public $pouzit_zboz3;
 
     /** @var float */
-    public $urceno_cerp_zuct = null;
+    public $urceno_cerp_zuct;
 
     /** @var float */
-    public $cerp_zuct = null;
+    public $cerp_zuct;
 
     /** @var int */
     public $rezim = 0;

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -14,7 +14,7 @@ class Receipt {
     /**
      * Head part: message identifier
      * @var string */
-    public $uuid_zpravy = FALSE;
+    public $uuid_zpravy;
 
     /**
      * Head part: first sending
@@ -22,66 +22,66 @@ class Receipt {
     public $prvni_zaslani = TRUE;
 
     /** @var string */
-    public $dic_popl = FALSE;
+    public $dic_popl;
 
     /** @var string */
-    public $dic_poverujiciho = FALSE;
+    public $dic_poverujiciho;
 
     /** @var string */
-    public $id_provoz = FALSE;
+    public $id_provoz;
 
     /** @var string */
-    public $id_pokl = FALSE;
+    public $id_pokl;
 
     /** @var string */
-    public $porad_cis = FALSE;
+    public $porad_cis;
 
     /** @var \DateTime */
-    public $dat_trzby = FALSE;
+    public $dat_trzby;
 
     /** @var float */
-    public $celk_trzba = FALSE;
+    public $celk_trzba;
 
     /** @var float */
-    public $zakl_nepodl_dph = FALSE;
+    public $zakl_nepodl_dph = null;
 
     /** @var float */
-    public $zakl_dan1 = FALSE;
+    public $zakl_dan1 = null;
 
     /** @var float */
-    public $dan1 = FALSE;
+    public $dan1 = null;
 
     /** @var float */
-    public $zakl_dan2 = FALSE;
+    public $zakl_dan2 = null;
 
     /** @var float */
-    public $dan2 = FALSE;
+    public $dan2 = null;
 
     /** @var float */
-    public $zakl_dan3 = FALSE;
+    public $zakl_dan3 = null;
 
     /** @var float */
-    public $dan3 = FALSE;
+    public $dan3 = null;
 
     /** @var float */
-    public $cest_sluz = FALSE;
+    public $cest_sluz = null;
 
     /** @var float */
-    public $pouzit_zboz1 = FALSE;
+    public $pouzit_zboz1 = null;
 
     /** @var float */
-    public $pouzit_zboz2 = FALSE;
+    public $pouzit_zboz2 = null;
 
     /** @var float */
-    public $pouzit_zboz3 = FALSE;
+    public $pouzit_zboz3 = null;
 
     /** @var float */
-    public $urceno_cerp_zuct = FALSE;
+    public $urceno_cerp_zuct = null;
 
     /** @var float */
-    public $cerp_zuct = FALSE;
+    public $cerp_zuct = null;
 
     /** @var int */
-    public $rezim = FALSE;
+    public $rezim;
 
 }

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -82,6 +82,6 @@ class Receipt {
     public $cerp_zuct = null;
 
     /** @var int */
-    public $rezim;
+    public $rezim = 0;
 
 }

--- a/src/Utils/Format.php
+++ b/src/Utils/Format.php
@@ -5,7 +5,7 @@ namespace Ondrejnov\EET\Utils;
 class Format {
 
     public static function price($value) {
-        return $value === false ? $value : number_format($value, 2, '.', '');
+        return $value === null ? $value : number_format($value, 2, '.', '');
     }
 
     public static function BKP($code) {
@@ -16,7 +16,7 @@ class Format {
 		$to_unset = array();
 		
 		foreach ($data as $k => $v) {
-			if ($v === false) $to_unset[] = $k;
+			if ($v === null) $to_unset[] = $k;
 		}
 		
 		foreach ($to_unset as $k) {

--- a/src/Utils/Format.php
+++ b/src/Utils/Format.php
@@ -5,11 +5,25 @@ namespace Ondrejnov\EET\Utils;
 class Format {
 
     public static function price($value) {
-        return number_format($value, 2, '.', '');
+        return $value === false ? $value : number_format($value, 2, '.', '');
     }
 
     public static function BKP($code) {
         return implode('-', str_split(strtoupper($code), 8));
     }
-
+	
+	public static function unsetInvalidKeys($data) {
+		$to_unset = array();
+		
+		foreach ($data as $k => $v) {
+			if ($v === false) $to_unset[] = $k;
+		}
+		
+		foreach ($to_unset as $k) {
+			unset($data[$k]);
+		}
+		
+		return $data;
+	}
+	
 }

--- a/src/Utils/Format.php
+++ b/src/Utils/Format.php
@@ -12,18 +12,4 @@ class Format {
         return implode('-', str_split(strtoupper($code), 8));
     }
 	
-	public static function unsetInvalidKeys($data) {
-		$to_unset = array();
-		
-		foreach ($data as $k => $v) {
-			if ($v === null) $to_unset[] = $k;
-		}
-		
-		foreach ($to_unset as $k) {
-			unset($data[$k]);
-		}
-		
-		return $data;
-	}
-	
 }


### PR DESCRIPTION
Sending zeroes in attributes which is not specified in request might cause disastrous consequences. According to specification and official recommendations unfilled attributies should not be present in the soap xml - without this update i see them in last request.