### PR TITLE
fix php 7.2. ErrorException on processWarnings

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -341,7 +341,7 @@ class Dispatcher {
      */
     private function processWarnings($warnings) {
         $result = array();
-        if(\count($warnings) === 1) {
+        if($warnings instanceof \stdClass) {
             $result[\intval($warnings->kod_varov)] = $this->getWarningMsg($warnings->kod_varov);
         } else {
             foreach ($warnings as $warning) {


### PR DESCRIPTION
Fix php 7.2 ErrorException: count(): Parameter must be an array or an object that implements Countable